### PR TITLE
Fix strong naming issues and min TopShelf version for TopShelf 4.0

### DIFF
--- a/Topshelf.Autofac.Sample/Topshelf.Autofac.Sample.csproj
+++ b/Topshelf.Autofac.Sample/Topshelf.Autofac.Sample.csproj
@@ -48,12 +48,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.1\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Topshelf.Autofac">
-      <HintPath>..\packages\Topshelf.Autofac.2.0.0\lib\Topshelf.Autofac.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -63,6 +60,12 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Topshelf.Autofac\Topshelf.Autofac.csproj">
+      <Project>{96145823-7447-42fe-81bc-9aada1c423b1}</Project>
+      <Name>Topshelf.Autofac</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Topshelf.Autofac.Sample/packages.config
+++ b/Topshelf.Autofac.Sample/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
-  <package id="Topshelf.Autofac" version="2.0.0" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.1" targetFramework="net452" />
 </packages>

--- a/Topshelf.Autofac/Topshelf.Autofac.csproj
+++ b/Topshelf.Autofac/Topshelf.Autofac.csproj
@@ -46,8 +46,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.0.0\lib\net452\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.1\lib\net452\Topshelf.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Topshelf.Autofac/Topshelf.Autofac.nuspec
+++ b/Topshelf.Autofac/Topshelf.Autofac.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Topshelf.Autofac</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>Topshelf.Autofac</title>
     <authors>Alexandr Nikitin</authors>
     <owners>qwesoftware</owners>
@@ -15,7 +15,7 @@
     <tags>Topshelf Autofac</tags>
     <dependencies>
       <dependency id="Autofac" version="[3.0.0,4.0.0)" />
-      <dependency id="TopShelf" version="[3.0.0,5.0.0)" />
+      <dependency id="TopShelf" version="[4.0.1,5.0.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/Topshelf.Autofac/packages.config
+++ b/Topshelf.Autofac/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net40" />
-  <package id="Topshelf" version="4.0.0" targetFramework="net452" />
+  <package id="Topshelf" version="4.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Topshelf 4.0 is now strong named, which was patched in 4.0.1, so this package need to be updated to support 4.0. 

Note that 4.0.1 should be the minium version for this patch. I versioned as 2.0.1. 

I believe 2.0.0 should have had a min version set to 4.0.0. 