### PR TITLE
upgraded topshelf prerelease version

### DIFF
--- a/Topshelf.Autofac.Sample/Topshelf.Autofac.Sample.csproj
+++ b/Topshelf.Autofac.Sample/Topshelf.Autofac.Sample.csproj
@@ -37,8 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.8.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.8.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.8.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.8.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration.Install" />
@@ -49,8 +49,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=4.1.0.117, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Topshelf.4.1.0.117-develop\lib\net452\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=4.0.4.161, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.4.0.4.161-develop\lib\net452\Topshelf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Topshelf.Autofac.Sample/packages.config
+++ b/Topshelf.Autofac.Sample/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.8.0" targetFramework="net452" />
-  <package id="Topshelf" version="4.1.0.117-develop" targetFramework="net47" />
+  <package id="Autofac" version="4.8.1" targetFramework="net47" />
+  <package id="Topshelf" version="4.0.4.161-develop" targetFramework="net47" />
   <package id="Topshelf.Autofac" version="3.1.1" targetFramework="net452" />
 </packages>

--- a/Topshelf.Autofac/Topshelf.Autofac.csproj
+++ b/Topshelf.Autofac/Topshelf.Autofac.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.*" />
-    <PackageReference Include="Topshelf" Version="4.1.0.117-develop" />
+    <PackageReference Include="Topshelf" Version="4.0.4.161-develop" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Nothing more than references fixes to be able to use this with latests prerelease of topshelf. I had to use local nuget packages since latest topshelf has not pushed the Topshelf.ServiceInstaller package, but I downloaded those from the build system in topshelf.